### PR TITLE
Change git push default mode to current

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -84,8 +84,8 @@ prompt = false
 rebase = preserve
 
 [push]
-# Default push should only push the current branch to its push target, regardless of its remote name
-default = upstream
+# Default push will only push the current branch to a branch of the same name
+default = current
 # When pushing, also push tags whose commit-ishs are now reachable upstream
 followTags = true
 


### PR DESCRIPTION
As seen in https://git-scm.com/docs/git-config, simple mode is the default in git 2.0