### PR TITLE
Add github template for issues and PR

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+Provide general introduction to the issue and why it is relevant to this repository.
+
+## Process
+Ordered list the process to finding and recreating the issue, example below.
+
+1. 
+
+## Expected result
+What you would expect to have resulted from this process.
+
+## Current result
+Describe what you you currently experience from this process, and thereby explain the bug.
+
+## Platform informations
+Give details about the tested platform (browser, versions...)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Status
+**READY/WIP/WAITING**
+
+## Migrations
+YES | NO
+
+## Description
+A few sentences describing the overall goals of the pull request's commits.
+
+## Related issues
+[link]()
+
+## Todos
+- [ ] Complete changelog
+- [ ] Add tests
+
+## Deploy Notes
+Notes regarding deployment the contained body of work.  These should note any
+db migrations, etc.
+
+## Steps to Test or Reproduce
+Outline the steps to test or reproduce the PR here.
+
+```sh
+git pull --prune
+git checkout <feature_branch>
+bundle; script/server
+```
+
+1. 


### PR DESCRIPTION
Fix #16

I'm not happy with the issue template as it's not fitted for "idea" or "feature to implement" issues,
only for bugs.

If you have any idea :wink: 

## Todo

- <del>[ ] Add french templates as option, for customer projects only working in french see</del> #18
